### PR TITLE
Chore/add mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ and [socket.io](https://socket.io).
 
 ## Setup
 
-### With [mise](https://mise.jdx.dev) (faster)
+### With [mise](https://mise.jdx.dev)
 
 ```sh
 mise install
 ```
+
+Run `mise doctor` to debug installation issues.
 
 ### With [nvm](https://github.com/nvm-sh/nvm)
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,20 @@ and [socket.io](https://socket.io).
 
 ## Setup
 
-- Get Node: <https://nodejs.org/en/download>
-- Enable Corepack:
+### With [mise](https://mise.jdx.dev) (faster)
+
+```sh
+mise install
+```
+
+### With [nvm](https://github.com/nvm-sh/nvm)
+
+```sh
+nvm install
+corepack enable
+```
+
+### With [Node.js](https://nodejs.org/)
 
 ```sh
 corepack enable
@@ -45,13 +57,4 @@ Create a `.env.production` file to specify the Prod API url:
 
 ```.env.production
 VITE_API_URL=https://your-api-url.foo
-```
-
-## Misc
-
-### Link to Netlify
-
-```sh
-pnpm install netlify-cli -g
-netlify link
 ```

--- a/docs/netlify.md
+++ b/docs/netlify.md
@@ -1,0 +1,8 @@
+# Netlify
+
+## Link to Netlify
+
+```sh
+pnpm install netlify-cli -g
+netlify link
+```

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,9 @@
+[settings]
+# Use the Node version from .nvmrc
+idiomatic_version_file_enable_tools = ['node']
+# Allow the use of the postinstall hook
+experimental=true
+
+[hooks]
+# Enabling corepack will install the `pnpm` package manager specified in package.json
+postinstall = 'corepack enable'


### PR DESCRIPTION
- Add [mise](https://mise.jdx.dev) configuration for faster setup
- Nvm will continue to work.